### PR TITLE
CI(semantic release versioning): Bumped version to 0.1.0

### DIFF
--- a/ladybug_comfort/__init__.py
+++ b/ladybug_comfort/__init__.py
@@ -7,7 +7,8 @@ Properties:
         for human geometry.  Each row refers to an degree of azimuth and each
         colum refers to a degree of altitude.
 """
-__version__ = "0.0.1"
+
+__version__ = '0.1.0'
 
 from ._loadmannequin import load_solarcal_splines
 


### PR DESCRIPTION
turns out since we imported the repository and tag 0.1.0 already exists we can't go backwards. This should let the bump to happen successfully.