### PR TITLE
fix(docs): build docs in separate step to PyPi deployment

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "bash deploy.sh ${nextRelease.version}"
+                "publishCmd": "bash deploy.sh"
             }
         ]
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 install:
  - pip install -r dev-requirements.txt
+ - pip install -r requirements.txt
 
 
 script:
@@ -19,15 +20,23 @@ jobs:
   include:
     - stage: deploy
       if: branch = master AND (NOT type IN (pull_request))
-      before_install: npm i -g npm@6.6.0
-      python: "3.6"
+      before_install:
+      - npm i -g npm@6.6.0
+      python:
+      - "3.6"
       install:
       - pip install -r dev-requirements.txt
+      - pip install -r requirements.txt
       - npm install @semantic-release/exec
       script:
-        - git config --global user.name "ladybugbot"
-        - git config --global user.email "release@ladybug.tools"
-        - npx semantic-release
+      - git config --global user.email "releases@ladybug.tools"
+      - git config --global user.name "ladybugbot"
+      - npx semantic-release
+    - stage: docs
+      if: branch = master AND (NOT type IN (pull_request))
+      script:
+      - sphinx-apidoc -f -e -d 4 -o ./docs ./ladybug_comfort
+      - sphinx-build -b html ./docs ./docs/_build/docs
       deploy:
         provider: pages
         skip_cleanup: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,26 +1,6 @@
 #!/bin/sh
 
-deploy_to_pypi() {
-  echo "Building distribution"
-  python setup.py sdist bdist_wheel
-  echo "Pushing new version to PyPi"
-  twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
-}
-
-build_docs() {
-  echo "Building documentation files"
-  sphinx-apidoc -f -e -d 4 -o ./docs ./ladybug_comfort
-  sphinx-build -b html ./docs ./docs/_build/docs -D release=$1 -D version=$1
-}
-
-
-if [ -n "$1" ]
-then
-  NEXT_RELEASE_VERSION=$1
-else
-  echo "A release version must be supplied"
-  exit 1
-fi
-
-deploy_to_pypi
-build_docs $NEXT_RELEASE_VERSION
+echo "Building distribution"
+python setup.py sdist bdist_wheel
+echo "Pushing new version to PyPi"
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-git+https://github.com/ladybug-tools/ladybug.git@development
 coverage==4.5.2
 coveralls==1.5.1
 pytest==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+lbt-ladybug>=0.7.0


### PR DESCRIPTION
This commit is trying to bring this repo in sync with the structure of the ladybug tool template repo. It's taking a cue from [this commit here](https://github.com/ladybug-tools/honeybee-core/commit/deeb42245bf83a168d9440fcff3ad3bf8aafa39f)