### PR TITLE
ci(dependabot): Add config file for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Adding this config file means that, whenever there is a new release of ladybug-core on PyPI, dependabot will immediately send a PR to this repo to ensure that there is a release of ladybug-comfort that is compatible with this version of ladybug-core.

Given that we have auto-merging turned on for this repo, this PR should be automatically merged if the tests pass, meaning there will automatically be a new release of ladybug-comfort whenever we release ladybug-core.