### PR TITLE
fix(utci): Change default UTCI wind speed to be 0.5 m/s

### DIFF
--- a/ladybug_comfort/collection/utci.py
+++ b/ladybug_comfort/collection/utci.py
@@ -30,8 +30,9 @@ class UTCI(ComfortCollection):
             analysis. If None, this will be the same as the air_temperature.
         wind_speed: Data Collection of meteorological wind speed values in m/s
             (measured 10 m above the ground) or a single wind speed value to be
-            used for the whole analysis. If None, this will default to a very
-            low wind speed of 0.1 m/s.
+            used for the whole analysis. If None, this will default to a low
+            wind speed of 0.5 m/s, which is the lowest input speed that is
+            recommended for the UTCI model.
         comfort_parameter: Optional UTCIParameter object to specify parameters under
             which conditions are considered acceptable. If None, default will
             assume comfort thresholds consistent with those used by meterologists
@@ -101,7 +102,7 @@ class UTCI(ComfortCollection):
             self._wind_speed = self._check_input(
                 wind_speed, Speed, 'm/s', 'air_speed')
         else:
-            self._wind_speed = [0.1] * self.calc_length
+            self._wind_speed = [0.5] * self.calc_length
 
         # check that all input data collections are aligned.
         BaseCollection.are_collections_aligned(self._input_collections)
@@ -125,9 +126,10 @@ class UTCI(ComfortCollection):
         Args:
             epw: A ladybug EPW object from which the UTCI object will be created.
             include_wind: Set to True to include the EPW wind speed in the calculation.
-                Setting to False will assume a condition that is shielded from wind
-                where the human experiences a very low wind speed of 0.1 m/s.
-                Default is True to include wind.
+                Setting to False will assume a condition that is shielded from
+                wind where the human subject experiences a low wind speed of 0.5 m/s,
+                which is the lowest input speed that is recommended for the UTCI
+                model. Default: True to include wind.
             include_sun: Set to True to include the mean radiant temperature (MRT) delta
                 from both shortwave solar falling directly on people and long wave
                 radiant exchange with the sky. Setting to False will assume a shaded
@@ -161,7 +163,7 @@ class UTCI(ComfortCollection):
             print(utci_protected.percent_neutral)  # comfortable % without sun + wind
         """
         # Get wind and mrt inputs
-        wind_speed = epw.wind_speed if include_wind is True else 0.1
+        wind_speed = epw.wind_speed if include_wind is True else 0.5
         if include_sun is True:
             solarcal_obj = OutdoorSolarCal(epw.location, epw.direct_normal_radiation,
                                            epw.diffuse_horizontal_radiation,

--- a/ladybug_comfort/utci.py
+++ b/ladybug_comfort/utci.py
@@ -93,7 +93,7 @@ def universal_thermal_climate_index(ta, tr, vel, rh):
         3.45433048e-6 * ta * ta * vel * d_tr + \
         -3.77925774e-7 * ta * ta * ta * vel * d_tr + \
         -1.69699377e-9 * ta * ta * ta * ta * vel * d_tr + \
-        1.69992415e-4 * vel*vel*d_tr + \
+        1.69992415e-4 * vel * vel * d_tr + \
         -4.99204314e-5 * ta * vel * vel * d_tr + \
         2.47417178e-7 * ta * ta * vel * vel * d_tr + \
         1.07596466e-8 * ta * ta * ta * vel * vel * d_tr + \
@@ -327,20 +327,17 @@ def calc_missing_utci_input(target_utci, utci_inputs,
     if utci_inputs['ta'] is None and utci_inputs['tr'] is None:
         def fn(x):
             return universal_thermal_climate_index(
-                x, x, utci_inputs['vel'], utci_inputs['rh']
-                ) - target_utci
+                x, x, utci_inputs['vel'], utci_inputs['rh']) - target_utci
         missing_key = ('ta', 'tr')
     elif utci_inputs['ta'] is None:
         def fn(x):
             return universal_thermal_climate_index(
-                x, utci_inputs['tr'], utci_inputs['vel'], utci_inputs['rh']
-                ) - target_utci
+                x, utci_inputs['tr'], utci_inputs['vel'], utci_inputs['rh']) - target_utci
         missing_key = 'ta'
     elif utci_inputs['tr'] is None:
         def fn(x):
             return universal_thermal_climate_index(
-                utci_inputs['ta'], x, utci_inputs['vel'], utci_inputs['rh']
-                ) - target_utci
+                utci_inputs['ta'], x, utci_inputs['vel'], utci_inputs['rh']) - target_utci
         missing_key = 'tr'
     elif utci_inputs['vel'] is None:
         def fn(x):
@@ -350,8 +347,7 @@ def calc_missing_utci_input(target_utci, utci_inputs,
     else:
         def fn(x):
             return universal_thermal_climate_index(
-                utci_inputs['ta'], utci_inputs['tr'], utci_inputs['vel'], x
-                ) - target_utci
+                utci_inputs['ta'], utci_inputs['tr'], utci_inputs['vel'], x) - target_utci
         missing_key = 'rh'
 
     # Solve for the missing input using the function.

--- a/tests/utci_test.py
+++ b/tests/utci_test.py
@@ -223,7 +223,7 @@ def test_init_utci_collection():
 
     assert utci_obj.comfort_model == 'Universal Thermal Climate Index'
     assert utci_obj.calc_length == calc_length
-    str(utci_obj)  # test that the string representaiton is ok
+    str(utci_obj)  # test that the string representation is ok
 
     assert isinstance(utci_obj.air_temperature, HourlyContinuousCollection)
     assert len(utci_obj.air_temperature.values) == calc_length
@@ -250,7 +250,7 @@ def test_utci_collection_defaults():
 
     assert isinstance(utci_obj.wind_speed, HourlyContinuousCollection)
     assert len(utci_obj.wind_speed.values) == calc_length
-    assert utci_obj.wind_speed[0] == 0.1
+    assert utci_obj.wind_speed[0] == 0.5
 
     assert isinstance(utci_obj.comfort_parameter, UTCIParameter)
     default_par = UTCIParameter()


### PR DESCRIPTION
After [some discussion](https://discourse.ladybug.tools/t/ladybug-default-windspeed-in-utci-calculator-component/10838/9), it seems 0.5 m/s is the lowest recommended wind speed for the UTCI model. So this commit changes the library to use this as a default.