### PR TITLE
fix(collection): Relax data type check of relative humidity

### DIFF
--- a/ladybug_comfort/collection/pmv.py
+++ b/ladybug_comfort/collection/pmv.py
@@ -12,7 +12,7 @@ from ladybug.psychrometrics import humid_ratio_from_db_rh
 
 from ladybug.datatype.temperature import Temperature, MeanRadiantTemperature, \
     StandardEffectiveTemperature, AirTemperature
-from ladybug.datatype.fraction import RelativeHumidity, HumidityRatio, \
+from ladybug.datatype.fraction import Fraction, RelativeHumidity, HumidityRatio, \
     PercentagePeopleDissatisfied
 from ladybug.datatype.speed import Speed, AirSpeed
 from ladybug.datatype.energyflux import MetabolicRate
@@ -120,7 +120,7 @@ class PMV(ComfortCollection):
         # check and set required inputs
         self._air_temperature = air_temperature.values
         self._rel_humidity = self._check_input(
-            rel_humidity, RelativeHumidity, '%', 'rel_humidity')
+            rel_humidity, Fraction, '%', 'rel_humidity')
 
         # check parameters with defaults
         if rad_temperature is not None:

--- a/ladybug_comfort/collection/utci.py
+++ b/ladybug_comfort/collection/utci.py
@@ -11,7 +11,7 @@ from ladybug._datacollectionbase import BaseCollection
 
 from ladybug.datatype.temperature import Temperature, MeanRadiantTemperature, \
     AirTemperature, UniversalThermalClimateIndex
-from ladybug.datatype.fraction import RelativeHumidity
+from ladybug.datatype.fraction import Fraction, RelativeHumidity
 from ladybug.datatype.speed import Speed, WindSpeed
 from ladybug.datatype.thermalcondition import ThermalComfort, ThermalCondition, \
     ThermalConditionFivePoint, ThermalConditionSevenPoint, \
@@ -89,7 +89,7 @@ class UTCI(ComfortCollection):
         # check required inputs
         self._air_temperature = air_temperature.values
         self._rel_humidity = self._check_input(
-            rel_humidity, RelativeHumidity, '%', 'rel_humidity')
+            rel_humidity, Fraction, '%', 'rel_humidity')
 
         # check inputs with defaults
         if rad_temperature is not None:


### PR DESCRIPTION
The data collections coming out of the energy simulation are for the generic Fraction data type and not RelativeHumidity. So I'm relaxing the type checking a bit to make sure this happens seamlessly.